### PR TITLE
posthog remove hardcode

### DIFF
--- a/worker/tasks/run_repo.py
+++ b/worker/tasks/run_repo.py
@@ -158,7 +158,7 @@ Use these prompts to understand the point of certain included prompts, and how t
 """
 
 def _run_agent_session(agent_id: int, docker_id: str, prompt: str, tool_slugs: list[str], previousMessages: list | None = None):
-    dynamic_tools, prompts = asyncio.run(load_tools(tool_slugs))
+    dynamic_tools, prompts = asyncio.run(load_tools(tool_slugs, agent_id=agent_id))
     posthog = Posthog(
         (os.environ.get("POSTHOG_API_KEY", "")),
         host=os.environ.get("POSTHOG_HOST", "https://us.i.posthog.com"),

--- a/worker/tools/__init__.py
+++ b/worker/tools/__init__.py
@@ -73,7 +73,7 @@ def _ensure_sync_tool(tool):
     return tool
 
 
-async def load_tools(slugs: list[str]) -> tuple[list, list]:
+async def load_tools(slugs: list[str], agent_id: int = None) -> tuple[list, list]:
     loaded = []
     prompts = []
     for slug in slugs:
@@ -86,7 +86,11 @@ async def load_tools(slugs: list[str]) -> tuple[list, list]:
         if not (prompt := getattr(mod, "prompt", None)):
             raise AttributeError(f"{mod.__name__} missing prompts")
         
-        tools = getter()
+        sig = inspect.signature(getter)
+        if "agent_id" in sig.parameters and agent_id is not None:
+            tools = getter(agent_id=agent_id)
+        else:
+            tools = getter()
         if inspect.isawaitable(tools):
             tools = await tools
         loaded.extend(_ensure_sync_tool(t) for t in tools)

--- a/worker/tools/posthog/documentation.py
+++ b/worker/tools/posthog/documentation.py
@@ -1,7 +1,5 @@
 from . import get_toolkit
 
-toolkit = get_toolkit()
-
 prompt = """
 <posthog/documentation>
 
@@ -15,10 +13,9 @@ tools:
 </posthog/documentation>
 """
 
-async def get_tools():
+async def get_tools(agent_id: int):
+    toolkit = get_toolkit(agent_id)
     names = ["docs-search"]
     tools = await toolkit.get_tools()
     doc_tools = [tool for tool in tools if tool.name in names]
     return doc_tools
-
-

--- a/worker/tools/posthog/error.py
+++ b/worker/tools/posthog/error.py
@@ -1,7 +1,5 @@
 from . import get_toolkit
 
-toolkit = get_toolkit()
-
 prompt = """
 <posthog/error>
 
@@ -16,7 +14,8 @@ tools:
 </posthog/error>
 """
 
-async def get_tools():
+async def get_tools(agent_id: int):
+    toolkit = get_toolkit(agent_id)
     names = ["error-details", "list-errors"]
     tools = await toolkit.get_tools()
     error_tools = [tool for tool in tools if tool.name in names]

--- a/worker/tools/posthog/insights.py
+++ b/worker/tools/posthog/insights.py
@@ -1,7 +1,5 @@
 from . import get_toolkit
 
-toolkit = get_toolkit()
-
 prompt = """
 <posthog/insights>
 
@@ -24,7 +22,8 @@ tools:
 </posthog/insights>
 """
 
-async def get_tools():
+async def get_tools(agent_id: int):
+    toolkit = get_toolkit(agent_id)
     names = [
         "insight-create-from-query",
         "insight-delete",

--- a/worker/tools/posthog/query_runner.py
+++ b/worker/tools/posthog/query_runner.py
@@ -1,7 +1,5 @@
 from . import get_toolkit
 
-toolkit = get_toolkit()
-
 prompt = """
 <posthog/query_runner>
 
@@ -18,7 +16,8 @@ tools:
 </posthog/query_runner>
 """
 
-async def get_tools():
+async def get_tools(agent_id: int):
+    toolkit = get_toolkit(agent_id)
     names = ["query-run", "query-generate-hogql-from-question", "docs-search"]
     tools = await toolkit.get_tools()
     query_tools = [tool for tool in tools if tool.name in names]


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Fetch PostHog API key per agent via new backend endpoint and pass agent_id through tool loading to initialize PostHog tools dynamically.
> 
> - **Backend**:
>   - Add `GET /api/internals/agents/{agent_id}/posthog-key/` to return a user's PostHog `api_key` for an agent in `workspaces/views.py`.
> - **Worker**:
>   - Pass `agent_id` to `load_tools` in `_run_agent_session` (`worker/tasks/run_repo.py`).
>   - Update `load_tools(slugs, agent_id)` to forward `agent_id` to tool modules when supported and keep prompts aggregation (`worker/tools/__init__.py`).
> - **PostHog Tools**:
>   - Replace env-based key with per-agent key fetched from backend; introduce simple toolkit cache (`worker/tools/posthog/__init__.py`).
>   - Update tool modules (`documentation.py`, `error.py`, `insights.py`, `query_runner.py`) to accept `agent_id` and initialize toolkit via `get_toolkit(agent_id)`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0e5619e89a0d741f550618587ab4fc92d1d6ba20. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->