### PR TITLE
Git branch feature integration

### DIFF
--- a/backend/workspaces/utils/createBranch.py
+++ b/backend/workspaces/utils/createBranch.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+import os
 
 from dulwich import porcelain
 from dulwich.repo import Repo
@@ -8,7 +9,9 @@ from integrations.services.github_app import get_installation_token
 from workspaces.models import Agent
 
 
-WORKSPACES_ROOT = Path("/Users/brandonpieczka/repos/codee/.data/agents")
+current_file = Path(__file__).resolve()
+default_root = current_file.parents[3] if len(current_file.parents) > 3 else current_file.parent
+WORKSPACES_ROOT = Path(os.getenv("WORKSPACES_ROOT", str(default_root / ".data/agents")))
 
 
 def _get_agent_repo_path(agent_id: int) -> Path:

--- a/worker/utils.py
+++ b/worker/utils.py
@@ -3,11 +3,16 @@ import os
 import time
 import logging
 from typing import Optional
+from pathlib import Path
 
 logger = logging.getLogger(__name__)
 
 STREAM_REDIS_URL = os.getenv("STREAM_REDIS_URL", "redis://localhost:6379/2")
 _stream_client: Optional[redis.Redis] = None
+
+current_file = Path(__file__).resolve()
+default_root = current_file.parents[1] if len(current_file.parents) > 1 else current_file.parent
+WORKSPACES_ROOT = Path(os.getenv("WORKSPACES_ROOT", str(default_root / ".data/agents")))
 
 
 def get_stream_client() -> redis.Redis:
@@ -61,5 +66,5 @@ def emit_done(agent_id: int, reason: str):
 
 
 def get_workspace_path(agent_id: int) -> str:
-    return f"/Users/brandonpieczka/repos/codee/.data/agents/{agent_id}"
+    return str(WORKSPACES_ROOT / str(agent_id))
 


### PR DESCRIPTION
Make `WORKSPACES_ROOT` configurable and default to the repo root to unify workspace paths across worker cloning and backend branch pushes.

The previous hardcoded path could lead to inconsistencies when operations were performed on different hosts or environments. This change ensures a consistent and configurable base directory for all agent workspaces.

---
[Slack Thread](https://kody-8rw3205.slack.com/archives/C0A3VLAPU2X/p1766297991882979?thread_ts=1766297991.882979&cid=C0A3VLAPU2X)

<a href="https://cursor.com/background-agent?bcId=bc-616475ac-6f50-4536-910c-a208bb54002a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-616475ac-6f50-4536-910c-a208bb54002a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

